### PR TITLE
Spin up Apollo Server with mock data

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,0 +1,24 @@
+const mockTransactions = [
+  {
+    date: "1205884800000",
+    amount: 8592,
+    transaction_code: "buy",
+    symbol: "amd",
+    price: "6.25868566899633460565155473886989057064056396484375",
+    total: "53774.62726801650693175815832",
+  },
+  {
+    date: "1211846400000",
+    amount: 5360,
+    transaction_code: "sell",
+    symbol: "amd",
+    price: "6.8846943545406844577883020974695682525634765625",
+    total: "36901.96174033806869374529924",
+  },
+];
+
+export const resolvers = {
+  Query: {
+    transactions: () => mockTransactions,
+  },
+};

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,4 +1,6 @@
-const mockTransactions = [
+import { Transactions } from "./types/Transactions";
+
+const mockTransactions: Transactions[] = [
   {
     date: "1205884800000",
     amount: 8592,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,0 +1,12 @@
+type Transaction {
+  date: String!
+  amount: Int!
+  transaction_code: String!
+  symbol: String!
+  price: String!
+  total: String!
+}
+
+type Query {
+  transactions: [Transaction]
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,52 @@
+import { ApolloServer } from "@apollo/server";
+import { startStandaloneServer } from "@apollo/server/standalone";
+
+const typeDefs = `#graphql
+    type Transaction {
+        date: String!
+        amount: Int!
+        transaction_code: String!
+        symbol: String!
+        price: String!
+        total: String!
+    }
+
+    type Query {
+        transactions: [Transaction]
+    }
+`;
+
+const mockTransactions = [
+  {
+    date: "1205884800000",
+    amount: 8592,
+    transaction_code: "buy",
+    symbol: "amd",
+    price: "6.25868566899633460565155473886989057064056396484375",
+    total: "53774.62726801650693175815832",
+  },
+  {
+    date: "1211846400000",
+    amount: 5360,
+    transaction_code: "sell",
+    symbol: "amd",
+    price: "6.8846943545406844577883020974695682525634765625",
+    total: "36901.96174033806869374529924",
+  },
+];
+
+const resolvers = {
+  Query: {
+    transactions: () => mockTransactions,
+  },
+};
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+});
+
+const { url } = await startStandaloneServer(server, {
+  listen: { port: 4000 },
+});
+
+console.log(`🚀  Server ready at: ${url}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,45 +1,10 @@
 import { ApolloServer } from "@apollo/server";
 import { startStandaloneServer } from "@apollo/server/standalone";
+import fs from "fs";
+import { resolvers } from "./resolvers.js";
 
-const typeDefs = `#graphql
-    type Transaction {
-        date: String!
-        amount: Int!
-        transaction_code: String!
-        symbol: String!
-        price: String!
-        total: String!
-    }
+const typeDefs = fs.readFileSync("src/schema.graphql", "utf8");
 
-    type Query {
-        transactions: [Transaction]
-    }
-`;
-
-const mockTransactions = [
-  {
-    date: "1205884800000",
-    amount: 8592,
-    transaction_code: "buy",
-    symbol: "amd",
-    price: "6.25868566899633460565155473886989057064056396484375",
-    total: "53774.62726801650693175815832",
-  },
-  {
-    date: "1211846400000",
-    amount: 5360,
-    transaction_code: "sell",
-    symbol: "amd",
-    price: "6.8846943545406844577883020974695682525634765625",
-    total: "36901.96174033806869374529924",
-  },
-];
-
-const resolvers = {
-  Query: {
-    transactions: () => mockTransactions,
-  },
-};
 const server = new ApolloServer({
   typeDefs,
   resolvers,

--- a/src/types/Transactions.ts
+++ b/src/types/Transactions.ts
@@ -1,0 +1,8 @@
+export type Transactions = {
+  date: string;
+  amount: number;
+  transaction_code: string;
+  symbol: string;
+  price: string;
+  total: string;
+};


### PR DESCRIPTION
### Summary
Created an apollo server that can respond to a simple GraphQL request, and return a response based on mock data.

### Steps followed
1. Following [Get Started doc](https://www.apollographql.com/docs/apollo-server/getting-started/) for Apollo Server, I laid down the minimal code needed to start an Apollo server. I adapted the Query, Schema, and the mock response to reflect the shape of [`transactions` data](https://www.mongodb.com/docs/atlas/sample-data/sample-analytics/#sample_analytics.transactions) I expect from MongoDB Sample Analytics database.
2. I launched the server locally, then submitted a GraphQL query using [Insomnia client](https://insomnia.rest/), then confirmed that the returned response matches the mock data. See the screenshots below.
3. By this point, all code lived in one file, `server.ts`. I split this code into additional files by functions, to keep the code organized as the feature set grows (additional files: `schema.graphql`, `resolvers.ts`, `types/Transactions.ts`

### Validation
In the screenshot below, we see that the GraphQL query for `transactions` submitted to `localhost:4000` did return the mocked data as expected ✅:

<img width="1874" alt="Screenshot 2024-06-06 at 10 26 39 AM" src="https://github.com/chohanbin/flywheel-data-service/assets/5660356/78aa4c68-0665-4881-a845-c504cb6ddd2f">


The mocked data was sampled from the actual data stored in Sample Analytics database.

⚠️ I converted the `date` field to a string representation of unix timestamp (having already tested that this is how the field gets represented by MongoDB Driver for Node.js). While MongoDB stores date in 64-bit integer, GraphQL supports `Int` of size 32-bit. So the timestamp from MongoDB cannot fit into GraphQL `Int` scalar type directly. [There are libraries](https://the-guild.dev/graphql/scalars/docs/scalars/timestamp) to support `Date` scalar, but **for the sake of simplicity, I will keep `date` field represented as a string field in the schema for now.** Ideally, `date` field will not remain a string field, to avoid confusion on future developers' expectations.

<img width="1590" alt="Screenshot 2024-06-06 at 10 24 03 AM" src="https://github.com/chohanbin/flywheel-data-service/assets/5660356/ec844013-a30a-4222-9686-1ddadec07a31">

PS:
⚠️ I realize that it isn't a good practice to copy data from the DB directly into the source code. The DB used in this project, [`sample_analytics` was created by MongoDB](https://www.mongodb.com/docs/atlas/sample-data/sample-analytics/) for the purpose of demonstration, so the data is public and fake. However, if this were real data in the production environment, there would be a risk of exposing sensitive customer data through the source code. I will keep this PR to illustrate the mistake that can be made.