### PR TITLE
Setup MongoDB Client

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -161,9 +161,10 @@ const config: Config = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "/dist/"
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.10.4",
-        "graphql": "^16.8.1"
+        "graphql": "^16.8.1",
+        "mongodb": "6.7"
       },
       "devDependencies": {
         "@eslint/js": "^8.56.0",
@@ -1865,6 +1866,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.7.tgz",
+      "integrity": "sha512-dCHW/oEX0KJ4NjDULBo3JiOaK5+6axtpBbS+ao2ZInoAL9/YRQLhXzSNAFz7hP4nzLkIqsfYAK/PDE3+XHny0Q==",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2198,6 +2207,19 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -2749,6 +2771,14 @@
       "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.7.0.tgz",
+      "integrity": "sha512-w2IquM5mYzYZv6rs3uN2DZTOBe2a0zXLj53TGDqwF4l6Sz/XsISrisXOJihArF9+BZ6Cq/GjVht7Sjfmri7ytQ==",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer-from": {
@@ -6057,6 +6087,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -6150,6 +6185,91 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.7.0.tgz",
+      "integrity": "sha512-TMKyHdtMcO0fYBNORiYdmM25ijsHs+Njs963r4Tro4OQZzqYigAzYQouwWRg4OIaiLRUEGUh/1UAcH5lxdSLIA==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/ms": {
@@ -6630,7 +6750,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7105,6 +7224,14 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@eslint/js": "^8.56.0",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.2",
+        "dotenv": "^16.4.5",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.3.0",
@@ -3357,6 +3358,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ee-first": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@apollo/server": "^4.10.4",
         "graphql": "^16.8.1",
-        "mongodb": "6.7"
+        "mongodb": "6.7",
+        "mongodb-memory-server": "^9.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^8.56.0",
@@ -2407,6 +2408,38 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2499,6 +2532,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -2511,6 +2552,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/b4a": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg=="
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2674,6 +2720,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bare-events": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.3.1.tgz",
+      "integrity": "sha512-sJnSOTVESURZ61XgEleqmP255T6zTYwHPwE4r6SssIh0U9/uDvfpdoJYpVUerJJZH2fueO+CdT8ZT+OC/7aZDA==",
+      "optional": true
+    },
     "node_modules/body-parser": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
@@ -2780,6 +2832,14 @@
       "integrity": "sha512-w2IquM5mYzYZv6rs3uN2DZTOBe2a0zXLj53TGDqwF4l6Sz/XsISrisXOJihArF9+BZ6Cq/GjVht7Sjfmri7ytQ==",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -3095,6 +3155,11 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3835,6 +3900,11 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -3935,6 +4005,44 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3970,6 +4078,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.0",
@@ -4272,6 +4399,39 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -4376,6 +4536,23 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5775,6 +5952,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6285,6 +6467,170 @@
         "node": ">=16"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.3.0.tgz",
+      "integrity": "sha512-ag1vbjsm1A2C/1arRlfCLRapY7L2JKsQgASvaFyTXFyfqf6wjVSfO3PhJ/KfkyntmwlMXe3sUjMkZKeD89qu8Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "mongodb-memory-server-core": "9.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.3.0.tgz",
+      "integrity": "sha512-8okAtOGWqSG37K7/TrvTfn43ORMh9LssIvd30XjHxvjWK7utmSTXr69XAhYvsDrHDwv7L23Ii6NJ4zMPpiFKuw==",
+      "dependencies": {
+        "async-mutex": "^0.4.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.4",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^7.0.4",
+        "mongodb": "^5.9.1",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.6.2",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.6.2",
+        "yauzl": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/bson": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "dependencies": {
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -6303,6 +6649,38 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -6481,8 +6859,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6530,7 +6906,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6573,6 +6948,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/picocolors": {
       "version": "1.0.1",
@@ -6618,8 +6998,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -6631,8 +7009,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -6645,8 +7021,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -6658,8 +7032,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -6674,8 +7046,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -6817,6 +7187,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -7053,7 +7428,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7218,6 +7592,28 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7281,6 +7677,19 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
+      "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -7420,6 +7829,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -7433,6 +7852,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.0.tgz",
+      "integrity": "sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -8128,6 +8555,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.1.3.tgz",
+      "integrity": "sha512-JCCdmlJJWv7L0q/KylOekyRaUrdEoUxWkWVcgorosTROCFWiS9p2NNPE9Yb91ak7b1N5SxAZEliWpspbZccivw==",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "description": "",
   "dependencies": {
     "@apollo/server": "^4.10.4",
-    "graphql": "^16.8.1"
+    "graphql": "^16.8.1",
+    "mongodb": "6.7"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "compile": "tsc",
-    "start": "npm run compile && node ./dist/server.js",
+    "start": "npm run compile && node ./dist/src/server.js",
     "test": "jest",
     "prepare": "husky",
     "lint": "eslint --fix {src,test}/**/*.{js,ts,jsx,tsx} --no-error-on-unmatched-pattern",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@eslint/js": "^8.56.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.2",
+    "dotenv": "^16.4.5",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "@apollo/server": "^4.10.4",
     "graphql": "^16.8.1",
-    "mongodb": "6.7"
+    "mongodb": "6.7",
+    "mongodb-memory-server": "^9.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",

--- a/src/datasources/analytics.ts
+++ b/src/datasources/analytics.ts
@@ -4,9 +4,9 @@ export default class AnalyticsDataSource {
   private client: MongoClient;
   private isConnected: boolean = false;
   private db: Db;
-  readonly dbName = "sample_analytics";
-  readonly collTxns = "transactions";
-  readonly fieldTxns = "transactions";
+  static readonly dbName = "sample_analytics";
+  static readonly collTxns = "transactions";
+  static readonly fieldTxns = "transactions";
 
   constructor(connString: string) {
     this.client = new MongoClient(connString);
@@ -15,9 +15,9 @@ export default class AnalyticsDataSource {
   public async initialize() {
     if (!this.isConnected) {
       await this.client.connect();
-      this.db = this.client.db(this.dbName);
+      this.db = this.client.db(AnalyticsDataSource.dbName);
       this.isConnected = true;
-      console.log(`Connected to MongoDB: ${this.dbName}`);
+      console.log(`Connected to MongoDB: ${AnalyticsDataSource.dbName}`);
     }
   }
 
@@ -35,7 +35,7 @@ export default class AnalyticsDataSource {
   }
 
   async transactionBatch(accountId: number) {
-    const coll = this.getCollection(this.collTxns);
+    const coll = this.getCollection(AnalyticsDataSource.collTxns);
     const txnBatch = await coll.findOne({ account_id: accountId });
     return txnBatch;
   }

--- a/src/datasources/analytics.ts
+++ b/src/datasources/analytics.ts
@@ -1,0 +1,36 @@
+import { MongoClient, Db } from "mongodb";
+
+export default class AnalyticsDataSource {
+  private client: MongoClient;
+  private isConnected: boolean = false;
+  private db: Db;
+  readonly dbName = "sample_analytics";
+  readonly collTxns = "transactions";
+  readonly fieldTxns = "transactions";
+
+  constructor(connString: string) {
+    this.client = new MongoClient(connString);
+  }
+
+  public async initialize() {
+    if (!this.isConnected) {
+      await this.client.connect();
+      this.db = this.client.db(this.dbName);
+      this.isConnected = true;
+      console.log(`Connected to MongoDB: ${this.dbName}`);
+    }
+  }
+
+  public getCollection(collectionName: string) {
+    if (!this.isConnected) {
+      throw new Error("MongoDB connection is not established");
+    }
+    return this.db.collection(collectionName);
+  }
+
+  async transactionBatch(accountId: number) {
+    const coll = this.getCollection(this.collTxns);
+    const txnBatch = await coll.findOne({ account_id: accountId });
+    return txnBatch;
+  }
+}

--- a/src/datasources/analytics.ts
+++ b/src/datasources/analytics.ts
@@ -21,6 +21,12 @@ export default class AnalyticsDataSource {
     }
   }
 
+  public async close(): Promise<void> {
+    await this.client.close();
+    this.isConnected = false;
+    console.log("MongoDB connection closed");
+  }
+
   public getCollection(collectionName: string) {
     if (!this.isConnected) {
       throw new Error("MongoDB connection is not established");

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,27 +1,5 @@
-import { Transaction } from "./types/Transaction";
-
-export const mockTransactions: Transaction[] = [
-  {
-    date: "1205884800000",
-    amount: 8592,
-    transaction_code: "buy",
-    symbol: "amd",
-    price: "6.25868566899633460565155473886989057064056396484375",
-    total: "53774.62726801650693175815832",
-  },
-  {
-    date: "1211846400000",
-    amount: 5360,
-    transaction_code: "sell",
-    symbol: "amd",
-    price: "6.8846943545406844577883020974695682525634765625",
-    total: "36901.96174033806869374529924",
-  },
-];
-
 export const resolvers = {
   Query: {
-    transactions: () => mockTransactions,
     transactionBatch: async (_, { accountId }, { dataSources }) => {
       return await dataSources.analytics.transactionBatch(accountId);
     },

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -22,5 +22,8 @@ export const mockTransactions: Transaction[] = [
 export const resolvers = {
   Query: {
     transactions: () => mockTransactions,
+    transactionBatch: async (_, { accountId }, { dataSources }) => {
+      return await dataSources.analytics.transactionBatch(accountId);
+    },
   },
 };

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -16,6 +16,5 @@ type TransactionBatch {
 }
 
 type Query {
-  transactions: [Transaction]
   transactionBatch(accountId: Int!): TransactionBatch
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -7,6 +7,15 @@ type Transaction {
   total: String!
 }
 
+type TransactionBatch {
+  account_id: Int!
+  transaction_count: Int!
+  bucket_start_date: String!
+  bucket_end_date: String!
+  transactions: [Transaction]
+}
+
 type Query {
   transactions: [Transaction]
+  transactionBatch(accountId: Int!): TransactionBatch
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,16 +2,40 @@ import { ApolloServer } from "@apollo/server";
 import { startStandaloneServer } from "@apollo/server/standalone";
 import fs from "fs";
 import { resolvers } from "./resolvers.js";
+import AnalyticsDataSource from "./datasources/analytics.js";
+import { config } from "dotenv";
+
+if (process.env.DB_CONN_STRING == null) config({ path: ".env.local" });
 
 const typeDefs = fs.readFileSync("src/schema.graphql", "utf8");
 
-const server = new ApolloServer({
-  typeDefs,
-  resolvers,
-});
+export interface ContextValue {
+  dataSources: {
+    analytics: AnalyticsDataSource;
+  };
+}
 
-const { url } = await startStandaloneServer(server, {
-  listen: { port: 4000 },
-});
+export const startServer = async () => {
+  const analyticsDS = new AnalyticsDataSource(process.env.DB_CONN_STRING);
+  await analyticsDS.initialize();
 
-console.log(`🚀  Server ready at: ${url}`);
+  const server = new ApolloServer({
+    typeDefs,
+    resolvers,
+  });
+
+  const { url } = await startStandaloneServer(server, {
+    context: async () => {
+      return {
+        dataSources: {
+          analytics: analyticsDS,
+        },
+      };
+    },
+    listen: { port: 4000 },
+  });
+
+  console.log(`🛞🚀 Flywheel Data Service ready at: ${url}`);
+};
+
+startServer();

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,15 @@ export const startServer = async () => {
     listen: { port: 4000 },
   });
 
+  const exitSignals = ["SIGTERM", "SIGINT"];
+  exitSignals.forEach((signal) => {
+    process.on(signal, async () => {
+      console.log(`Received ${signal}`);
+      await analyticsDS.close();
+      process.exit(0);
+    });
+  });
+
   console.log(`🛞🚀 Flywheel Data Service ready at: ${url}`);
 };
 

--- a/src/types/Transaction.ts
+++ b/src/types/Transaction.ts
@@ -1,3 +1,11 @@
+export type TransactionBatch = {
+  account_id: number;
+  transaction_count: number;
+  bucket_start_date: string;
+  bucket_end_date: string;
+  transactions: Transaction[];
+};
+
 export type Transaction = {
   date: string;
   amount: number;

--- a/test/seed/seed.ts
+++ b/test/seed/seed.ts
@@ -1,0 +1,60 @@
+import { TransactionBatch } from "../../src/types/Transaction";
+
+export const seedCollTxns: TransactionBatch[] = [
+  {
+    account_id: 123456,
+    transaction_count: 2,
+    bucket_start_date: new Date("2021-02-03").getTime().toString(),
+    bucket_end_date: new Date("2021-03-04").getTime().toString(),
+    transactions: [
+      {
+        date: new Date("2021-02-03").getTime().toString(),
+        amount: 10,
+        transaction_code: "buy",
+        symbol: "amzn",
+        price: "6.5",
+        total: "65",
+      },
+      {
+        date: new Date("2021-03-04").getTime().toString(),
+        amount: 20,
+        transaction_code: "buy",
+        symbol: "goog",
+        price: "12",
+        total: "240",
+      },
+    ],
+  },
+  {
+    account_id: 333333,
+    transaction_count: 3,
+    bucket_start_date: new Date("2020-04-04").getTime().toString(),
+    bucket_end_date: new Date("2022-06-06").getTime().toString(),
+    transactions: [
+      {
+        date: new Date("2020-04-04").getTime().toString(),
+        amount: 20,
+        transaction_code: "buy",
+        symbol: "amd",
+        price: "20",
+        total: "400",
+      },
+      {
+        date: new Date("2021-05-05").getTime().toString(),
+        amount: 10,
+        transaction_code: "sell",
+        symbol: "amd",
+        price: "25",
+        total: "500",
+      },
+      {
+        date: new Date("2022-06-06").getTime().toString(),
+        amount: 30,
+        transaction_code: "buy",
+        symbol: "amd",
+        price: "30",
+        total: "900",
+      },
+    ],
+  },
+];

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,6 +1,6 @@
 import { ApolloServer } from "@apollo/server";
 import fs from "fs";
-import { mockTransactions, resolvers } from "../src/resolvers";
+import { resolvers } from "../src/resolvers";
 import assert from "assert";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { MongoClient, Db, Collection, Document } from "mongodb";
@@ -53,30 +53,6 @@ describe("server", () => {
     } catch (err) {
       console.error("Failed to clean up test service:", err);
     }
-  });
-
-  describe("transactions", () => {
-    it("returns the mocked data of the correct format", async () => {
-      const response = await testServer.executeOperation({
-        query: `#graphql
-                    query ListTransactions {
-                        transactions {
-                            date
-                            amount
-                            transaction_code
-                            symbol
-                            price
-                            total
-                        }
-                    }
-                `,
-      });
-      assert(response.body.kind === "single");
-      expect(response.body.singleResult.errors).toBeUndefined();
-      expect(response.body.singleResult.data?.transactions).toEqual(
-        mockTransactions,
-      );
-    });
   });
 
   describe("transactionBatch", () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -56,7 +56,8 @@ describe("server", () => {
   });
 
   describe("transactionBatch", () => {
-    [...new Array(seedCollTxns.length)].forEach((_, index) => {
+    const indicesOfSeedBatches = [...Array(seedCollTxns.length).keys()];
+    indicesOfSeedBatches.forEach((index) => {
       const expectedBatch = seedCollTxns[index];
       const expectedAccountId = expectedBatch.account_id;
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -56,50 +56,52 @@ describe("server", () => {
   });
 
   describe("transactionBatch", () => {
-    it("returns the correct transaction batch for the given accountId", async () => {
-      const expectedBatch = seedCollTxns[0];
+    [...new Array(seedCollTxns.length)].forEach((_, index) => {
+      const expectedBatch = seedCollTxns[index];
       const expectedAccountId = expectedBatch.account_id;
 
-      const response = await testServer.executeOperation(
-        {
-          query: `#graphql
-            query GetTransactionBatch($accountId: Int!) {
-              transactionBatch(accountId: $accountId) {
-                account_id
-                transaction_count
-                bucket_start_date
-                bucket_end_date
-                transactions {
-                  date
-                  amount
-                  transaction_code
-                  symbol
-                  price
-                  total
+      it(`returns the correct transaction batch for the given accountId: ${expectedAccountId}`, async () => {
+        const response = await testServer.executeOperation(
+          {
+            query: `#graphql
+              query GetTransactionBatch($accountId: Int!) {
+                transactionBatch(accountId: $accountId) {
+                  account_id
+                  transaction_count
+                  bucket_start_date
+                  bucket_end_date
+                  transactions {
+                    date
+                    amount
+                    transaction_code
+                    symbol
+                    price
+                    total
+                  }
                 }
               }
-            }
-          `,
-          variables: { accountId: expectedAccountId },
-        },
-        {
-          contextValue: {
-            dataSources: {
-              analytics: testAnalyticsDS,
+            `,
+            variables: { accountId: expectedAccountId },
+          },
+          {
+            contextValue: {
+              dataSources: {
+                analytics: testAnalyticsDS,
+              },
             },
           },
-        },
-      );
+        );
 
-      assert(response.body.kind === "single");
-      expect(response.body.singleResult.errors).toBeUndefined();
-      const actualBatch = response.body.singleResult.data
-        ?.transactionBatch as TransactionBatch;
-      // Validate all fields except the hidden ID field.
-      for (const key in actualBatch) {
-        if (key === KEY_HIDDEN_OBJECT_ID) continue;
-        expect(actualBatch[key]).toEqual(expectedBatch[key]);
-      }
+        assert(response.body.kind === "single");
+        expect(response.body.singleResult.errors).toBeUndefined();
+        const actualBatch = response.body.singleResult.data
+          ?.transactionBatch as TransactionBatch;
+        // Validate all fields except the hidden ID field.
+        for (const key in actualBatch) {
+          if (key === KEY_HIDDEN_OBJECT_ID) continue;
+          expect(actualBatch[key]).toEqual(expectedBatch[key]);
+        }
+      });
     });
   });
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -2,17 +2,62 @@ import { ApolloServer } from "@apollo/server";
 import fs from "fs";
 import { mockTransactions, resolvers } from "../src/resolvers";
 import assert from "assert";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient, Db, Collection, Document } from "mongodb";
+import AnalyticsDataSource from "../src/datasources/analytics";
+import { seedCollTxns } from "./seed/seed";
+import { ContextValue } from "../src/server";
+import { TransactionBatch } from "../src/types/Transaction";
 
 const typeDefs = fs.readFileSync("src/schema.graphql", "utf8");
+const KEY_HIDDEN_OBJECT_ID = "_id";
+
+let testDbServer: MongoMemoryServer;
+let testDbClient: MongoClient;
+let testDb: Db;
+let testCollTxns: Collection<Document>;
+let testServer: ApolloServer<ContextValue>;
+let testAnalyticsDS: AnalyticsDataSource;
 
 describe("server", () => {
-  describe("transactions", () => {
-    it("returns the mocked data of the correct format", async () => {
-      const server = new ApolloServer({
+  beforeAll(async () => {
+    try {
+      // setup test database
+      testDbServer = await MongoMemoryServer.create();
+      const client = await new MongoClient(testDbServer.getUri());
+      testDbClient = await client.connect();
+      testDb = testDbClient.db(AnalyticsDataSource.dbName);
+      testCollTxns = testDb.collection(AnalyticsDataSource.collTxns);
+      await testCollTxns.insertMany(seedCollTxns);
+
+      // setup test analytics datasource
+      testAnalyticsDS = await new AnalyticsDataSource(testDbServer.getUri());
+      await testAnalyticsDS.initialize();
+
+      // setup test server
+      testServer = new ApolloServer<ContextValue>({
         typeDefs,
         resolvers,
       });
-      const response = await server.executeOperation({
+    } catch (err) {
+      console.error("Failed to set up test service:", err);
+    }
+  });
+
+  afterAll(async () => {
+    // shut down all resources started in beforeAll
+    try {
+      await testAnalyticsDS.close();
+      await testDbClient.close();
+      await testDbServer.stop();
+    } catch (err) {
+      console.error("Failed to clean up test service:", err);
+    }
+  });
+
+  describe("transactions", () => {
+    it("returns the mocked data of the correct format", async () => {
+      const response = await testServer.executeOperation({
         query: `#graphql
                     query ListTransactions {
                         transactions {
@@ -31,6 +76,54 @@ describe("server", () => {
       expect(response.body.singleResult.data?.transactions).toEqual(
         mockTransactions,
       );
+    });
+  });
+
+  describe("transactionBatch", () => {
+    it("returns the correct transaction batch for the given accountId", async () => {
+      const expectedBatch = seedCollTxns[0];
+      const expectedAccountId = expectedBatch.account_id;
+
+      const response = await testServer.executeOperation(
+        {
+          query: `#graphql
+            query GetTransactionBatch($accountId: Int!) {
+              transactionBatch(accountId: $accountId) {
+                account_id
+                transaction_count
+                bucket_start_date
+                bucket_end_date
+                transactions {
+                  date
+                  amount
+                  transaction_code
+                  symbol
+                  price
+                  total
+                }
+              }
+            }
+          `,
+          variables: { accountId: expectedAccountId },
+        },
+        {
+          contextValue: {
+            dataSources: {
+              analytics: testAnalyticsDS,
+            },
+          },
+        },
+      );
+
+      assert(response.body.kind === "single");
+      expect(response.body.singleResult.errors).toBeUndefined();
+      const actualBatch = response.body.singleResult.data
+        ?.transactionBatch as TransactionBatch;
+      // Validate all fields except the hidden ID field.
+      for (const key in actualBatch) {
+        if (key === KEY_HIDDEN_OBJECT_ID) continue;
+        expect(actualBatch[key]).toEqual(expectedBatch[key]);
+      }
     });
   });
 });


### PR DESCRIPTION
### Summary
Enable the GraphQL resolver to pull data from MongoDB, instead of returning a mock response. In an automated test, setup an in-memory MongoDB seeded with a small set of data.

### Main changes
1. Added a DataSource to connect to the MongoDB, in the style recommended by [Fetching Data doc](https://www.apollographql.com/docs/apollo-server/data/fetching-data) for Apollo Server.
  - Store [the DB connection string](https://www.mongodb.com/docs/manual/reference/connection-string/) in `.env.local` that won't be tracked by `git` (since it is a sensitive credential). Read the file, unless the environment variable for the DB connection string was already set in another way (perhaps passed into it with `docker run` - to be added later).
  - Ensure connecting to MongoClient only once at the start of the server (to [reduce latency in subsequent calls to the DB](https://www.mongodb.com/docs/manual/administration/connection-pool-overview/#create-and-use-a-connection-pool) in MongoDB doc), and ensure the connection closes [as the NodeJS server shuts down](https://dev.to/yusadolat/nodejs-graceful-shutdown-a-beginners-guide-40b6) (to ensure that the DB's connection pool can serve other requests)

2. Added `transactionBatch` query, that exposes `transactions` collection from MongoDB to the API.
  - Also, I deleted `transactions` query that was added in [a previous PR](https://github.com/chohanbin/flywheel-data-service/pull/2) to return mock data, without connecting to DB.

3. Added In-Memory MongoDB for test.
  - Following [this post](https://dev.to/gkampitakis/how-to-write-tests-for-applications-that-use-mongodb-as-a-storage-10bm) that compares the strategies to test applications using MongoDB, I chose to use `MongoMemoryServer` ([github](https://github.com/nodkz/mongodb-memory-server?tab=readme-ov-file#mongodb-in-memory-server), [doc](https://nodkz.github.io/mongodb-memory-server/docs/api/classes/mongo-memory-server)), that will allow me to create a MongoDB instance in-memory for automated testing.
  - I added an integration test, to test that the new `transactionBatch` query returns the correct document, according to the given input variable. Before any test case, the framework instantiates:
    - In-memory MongoDB with seed data
    - Data source to connect to the DB
    - Apollo server mounted with the data source
  - After all test cases have run, these resources are shutdown properly too.

### Validation

The connection to MongoDB gets established before the server announces itself ready.
Once the server is terminating, the connection to MongoDB gets closed properly. ✅ 
See the callouts in the code for where these logs are coming from.
<img width="1227" alt="Screenshot 2024-06-06 at 5 02 37 PM" src="https://github.com/chohanbin/flywheel-data-service/assets/5660356/bf4fd9f3-508d-4073-a8e8-1005ef0ed67f">

Making the GraphQL query `transactionBatch` with an accountID (`716662`) returns the matching records also found in MongoDB ✅ (viewed directly using [MongoDB Compass](https://www.mongodb.com/products/tools/compass) GUI client)
<img width="2065" alt="Screenshot 2024-06-06 at 5 23 48 PM" src="https://github.com/chohanbin/flywheel-data-service/assets/5660356/060e923a-f00d-4528-987d-345f4e8c162c">
