### PR TITLE
Add Query API for customer document

### DIFF
--- a/src/datasources/analytics.ts
+++ b/src/datasources/analytics.ts
@@ -34,6 +34,27 @@ export default class AnalyticsDataSource {
     return this.db.collection(collectionName);
   }
 
+  // TODO idea: sort the transactions by date at the DB level,
+  //            so that the frontend won't have to before displaying to the user.
+  //            Something like this could work:
+  // collection.aggregate([
+  //     {
+  //         $match: {
+  //             account_id: accountId
+  //         }
+  //     },
+  //     {
+  //         $project: {
+  //             _id: 0,
+  //             transactions: {
+  //                 $sortArray: {
+  //                     input: "$transactions",
+  //                     sortBy: { date: 1 }
+  //                 }
+  //             }
+  //         }
+  //     }
+  // ])
   async transactionBatch(accountId: number) {
     const coll = this.getCollection(AnalyticsDataSource.collTxns);
     const txnBatch = await coll.findOne({ account_id: accountId });

--- a/src/datasources/analytics.ts
+++ b/src/datasources/analytics.ts
@@ -5,6 +5,7 @@ export default class AnalyticsDataSource {
   private isConnected: boolean = false;
   private db: Db;
   static readonly dbName = "sample_analytics";
+  static readonly collCust = "customers";
   static readonly collTxns = "transactions";
   static readonly fieldTxns = "transactions";
 
@@ -34,6 +35,20 @@ export default class AnalyticsDataSource {
     return this.db.collection(collectionName);
   }
 
+  async customer(username: string) {
+    const coll = this.getCollection(AnalyticsDataSource.collCust);
+    // TODO: In rare cases, a given username or email
+    //       can resolve to multiple customers:
+    //       - email: 'jenn...9@...' => name: ['Alex ...', 'David ...']
+    //       - username: 'ihi...' => name: ['... Thomas', '... Smith']
+    //       - username: 'pat...5' => name: ['Jamie ...', 'Curtis ...']
+    // For now, just return the first match, but as soon as possible,
+    // understand whether these duplicates are allowed, and if so, in which case,
+    // then handle fetching a unique customer properly.
+    // (Perhaps by a combination of username and email, for example).
+    return await coll.findOne({ username: username });
+  }
+
   // TODO idea: sort the transactions by date at the DB level,
   //            so that the frontend won't have to before displaying to the user.
   //            Something like this could work:
@@ -57,7 +72,13 @@ export default class AnalyticsDataSource {
   // ])
   async transactionBatch(accountId: number) {
     const coll = this.getCollection(AnalyticsDataSource.collTxns);
-    const txnBatch = await coll.findOne({ account_id: accountId });
-    return txnBatch;
+    // TODO: In rare cases, a given account_id
+    //       can resolve to multiple transaction batches:
+    //       - account_id: '627...' returns 2 batches.
+    // For now, just return the first match, but as soon as possible,
+    // understand whether these duplicates are allowed, and if so, in which case,
+    // then handle multiple transaction batches properly.
+    // (Perhaps by merging the batches directly, if there won't be duplicate transactions).
+    return await coll.findOne({ account_id: accountId });
   }
 }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,5 +1,8 @@
 export const resolvers = {
   Query: {
+    customer: async (_, { username }, { dataSources }) => {
+      return await dataSources.analytics.customer(username);
+    },
     transactionBatch: async (_, { accountId }, { dataSources }) => {
       return await dataSources.analytics.transactionBatch(accountId);
     },

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,3 +1,13 @@
+type Customer {
+  username: String!
+  name: String!
+  email: String!
+  accounts: [Int!]
+  # TODO idea: Enable drilling into transactionBatch for each account.
+  #            That could enable an aggregate view of all transactions
+  #            for a customer in one GraphQL call.
+}
+
 type Transaction {
   date: String!
   amount: Int!
@@ -12,9 +22,10 @@ type TransactionBatch {
   transaction_count: Int!
   bucket_start_date: String!
   bucket_end_date: String!
-  transactions: [Transaction]
+  transactions: [Transaction!]
 }
 
 type Query {
+  customer(username: String!): Customer
   transactionBatch(accountId: Int!): TransactionBatch
 }

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -1,0 +1,7 @@
+export type AccountId = number;
+
+export type Account = {
+  account_id: AccountId;
+  limit: number;
+  products: string[];
+};

--- a/src/types/Customer.ts
+++ b/src/types/Customer.ts
@@ -1,0 +1,10 @@
+import { AccountId } from "./Account";
+
+export type Customer = {
+  username: string;
+  name: string;
+  address: string;
+  birthdate: string;
+  email: string;
+  accounts: AccountId[];
+};

--- a/src/types/Transaction.ts
+++ b/src/types/Transaction.ts
@@ -1,5 +1,7 @@
+import { AccountId } from "./Account";
+
 export type TransactionBatch = {
-  account_id: number;
+  account_id: AccountId;
   transaction_count: number;
   bucket_start_date: string;
   bucket_end_date: string;

--- a/test/seed/seed.ts
+++ b/test/seed/seed.ts
@@ -1,4 +1,24 @@
+import { Customer } from "../../src/types/Customer";
 import { TransactionBatch } from "../../src/types/Transaction";
+
+export const seedCollCust: Customer[] = [
+  {
+    username: "appleseed",
+    name: "Johnny Appleseed",
+    address: "678 Orchard Lane, Apple Valley, CA 92307",
+    birthdate: new Date("1974-09-26").getTime().toString(),
+    email: "johnny@appleseed.com",
+    accounts: [987123, 345987],
+  },
+  {
+    username: "poppins",
+    name: "Mary Poppins",
+    address: "1600 Dream St, Los Angeles, CA 90028",
+    birthdate: new Date("1964-12-23").getTime().toString(),
+    email: "merry@poppins.net",
+    accounts: [246801, 777777, 999999, 111111],
+  },
+];
 
 export const seedCollTxns: TransactionBatch[] = [
   {


### PR DESCRIPTION
### Summary
Added Query for `customer`, given a `username`. A `customer` can have multiple `accounts`. Therefore, using this Query and `transactionBatch` API, we can retrieve all transactions for a customer, given their `username`. 

### Main changes
- To enable `customer` Query, a new GraphQL schema, a TypeScript type, a resolver, a DB seed data, and an integration test case was added.
- Since [the previous PR](https://github.com/chohanbin/flywheel-data-service/pull/4) laid the foundation for adding a new API, this PR simply reuses the code structure to support a new API.

### Validation
Querying `customer`, given a specific `username` returned the same customer info found in MongoDB ✅:
<img width="1951" alt="Screenshot 2024-06-06 at 6 34 41 PM" src="https://github.com/chohanbin/flywheel-data-service/assets/5660356/95ef78af-1ee8-4cef-ae38-775571526e24">
