### PR TITLE
Run the service as a Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22
+WORKDIR /app
+COPY . .
+RUN npm install
+CMD ["npm", "start"]
+EXPOSE 4000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-Backend service exposing data API for Flywheel Trading app
+# Flywheel Data Service
+
+The mighty Flywheel Trading app's GraphQL API service. Its primary purpose is to serve user data to the web service.
+
+# How to run
+
+Launch the GraphQL API service locally (at port `4000` by default):
+
+### Using npm
+
+Create `.env.local` file that specifies which MongoDB to target (Replace `<CONNECTION_STRING>` with the target DB URI, e.g. `'mongodb+srv://.../sample_analytics?...'` or `mongodb://localhost:27017`)
+
+```shell
+DB_CONN_STRING=<CONNECTION_STRING>
+```
+
+From the repo root directory, invoke:
+
+```shell
+npm install
+npm start
+```
+
+### Using docker
+
+If this is your first time running this service, run:
+
+```shell
+# If the output to this command returns nothing,
+docker network ls | grep flywheel
+# Then run
+docker network create flywheel
+```
+
+Build the image with:
+
+```shell
+docker build -t flywheel-data-service .
+```
+
+Run a container (Replace `<CONNECTION_STRING>` with the target DB URI):
+
+```shell
+docker run -dp 127.0.0.1:4000:4000 \
+  --network flywheel \
+  -e DB_CONN_STRING='<CONNECTION_STRING>' \
+  flywheel-data-service
+```
+
+# ^TODO: Add instruction on how to allow this docker service to connect to mongodb://localhost:27017
+
+# How to run automated test
+
+From the repo root directory, invoke:
+
+```shell
+npm test
+```
+
+# Author
+
+Hanbin Cho

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,9 +4,6 @@ import fs from "fs";
 import { resolvers } from "./resolvers.js";
 import AnalyticsDataSource from "./datasources/analytics.js";
 import { config } from "dotenv";
-
-if (process.env.DB_CONN_STRING == null) config({ path: ".env.local" });
-
 const typeDefs = fs.readFileSync("src/schema.graphql", "utf8");
 
 export interface ContextValue {
@@ -14,6 +11,10 @@ export interface ContextValue {
     analytics: AnalyticsDataSource;
   };
 }
+
+// DB_CONN_STRING may be passed in as an in-line env variable with `docker run`.
+// Default to reading from .env.local if not provided.
+if (process.env.DB_CONN_STRING == null) config({ path: ".env.local" });
 
 export const startServer = async () => {
   const analyticsDS = new AnalyticsDataSource(process.env.DB_CONN_STRING);


### PR DESCRIPTION
### Summary
Enable the service to be containerized with `docker build` and run as a container with `docker run`

### Steps followed
1. Following [Get Started doc](https://docs.docker.com/get-started/02_our_app/) for Docker, I added a `Dockerfile`, specifying how to install the packages (`npm install`) and how to initiate the service (`npm start`)
2. Then I ran `docker build` and `docker run` like demonstrated in `Validation` section.

### Validation
I will demonstrate:
1. Building a docker image of this service.
2. Running a container based on that image.
3. Making a GraphQL query against the port that the container is listening to.

I will name my image `flywheel-data-service`, the same as this repo name.
I first checked that there is no such docker image registered yet:
```shell
> docker image ls | grep flywheel-data-service
(no matched string)
```

Then, from the repo root, I executed `docker build -t flywheel-data-service .`
```shell
> pwd
/Users/hanbin/Repos/flywheel-data-service
> docker build -t flywheel-data-service .
[+] Building 4.9s (12/12) FINISHED                                                                          docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                        0.0s
 => => transferring dockerfile: 151B                                                                                        0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                   0.4s
...
```

Then I checked that the docker image `flywheel-data-service` is now registered. ✅
```shell
> docker image ls | grep flywheel-data-service
flywheel-data-service          latest      ef5a219a931c   14 seconds ago      1.24GB
```

Then I started a container for this service at port 4000 with the following command, with `<CONNECTION_STRING>` replaced with the URI for the target DB on the internet (e.g. `'mongodb+srv://.../sample_analytics?...'`). This sets `process.env.DB_CONN_STRING` used within the service to connect to a MongoDB):
```shell
docker run -dp 127.0.0.1:4000:4000 \
  --network flywheel \
  -e DB_CONN_STRING='<CONNECTION_STRING>' \
  flywheel-data-service
```

`--network flywheel` is to allow this service to later communicate with the `flywheel-web-service` container over the same network (see [this doc](https://docs.docker.com/get-started/07_multi_container/)). This assumes that `flywheel` network is already created locally. Check its existence with:
```shell
docker network ls | grep flywheel
```
If not found, then simply execute:
```shell
docker network create flywheel
```

Once `docker run` is successful, it outputs a hash ID of the container.
I can check that it is running successfully with `docker logs <container-id-prefix>`  ✅
```shell
docker logs fb26bc31

> flywheel-data-service@1.0.0 start
> npm run compile && node ./dist/src/server.js


> flywheel-data-service@1.0.0 compile
> tsc

Connected to MongoDB: sample_analytics
🛞🚀 Flywheel Data Service ready at: http://localhost:4000/
```

I can see that the GraphQL query to port 4000 returns successfully too.  ✅
<img width="1712" alt="Screenshot 2024-06-06 at 8 04 15 PM" src="https://github.com/chohanbin/flywheel-data-service/assets/5660356/35c5905d-11e7-4904-a3f4-d603a698ae7e">
