### PR TITLE
Use the correct comment marker in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker run -dp 127.0.0.1:4000:4000 \
   flywheel-data-service
 ```
 
-# ^TODO: Add instruction on how to allow this docker service to connect to mongodb://localhost:27017
+// ^TODO: Add instruction on how to allow this docker service to connect to mongodb://localhost:27017
 
 # How to run automated test
 


### PR DESCRIPTION
In [the previous PR](https://github.com/chohanbin/flywheel-data-service/pull/6), I overlooked validating how `README.md` looked like after adding in a `TODO` comment in the latest commit. I commented using `#`, which means the [top-level header](https://www.markdownguide.org/basic-syntax/#headings) in a markdown file (`.md`). To keep it as a small comment, just use `//` instead of `#` for the line marker.

Before (left) and after (right):

<img width="2915" alt="Screenshot 2024-06-06 at 8 39 47 PM" src="https://github.com/chohanbin/flywheel-data-service/assets/5660356/d5cdfbed-a138-4f1b-a537-05f1f70e5716">
