### PR TITLE
Fetch customer by email not username

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Visit <http://localhost:4000> from your browser, to open up [Apollo Sandbox](htt
 Operation (omit fields as desired):
 
 ```graphql
-query GetCustomer($username: String!) {
-  customer(username: $username) {
+query GetCustomer($email: String!) {
+  customer(email: $email) {
     username
     name
     email
@@ -88,10 +88,10 @@ query GetCustomer($username: String!) {
 }
 ```
 
-Variables (replace `appleseed` with your target `username`):
+Variables (replace `appleseed` with your target `email`):
 
 ```javascript
-{ "username": "appleseed" }
+{ "email": "johnny@appleseed.com" }
 ```
 
 ### Query: transactionBatch

--- a/src/datasources/analytics.ts
+++ b/src/datasources/analytics.ts
@@ -35,7 +35,7 @@ export default class AnalyticsDataSource {
     return this.db.collection(collectionName);
   }
 
-  async customer(username: string) {
+  async customer(email: string) {
     const coll = this.getCollection(AnalyticsDataSource.collCust);
     // TODO: In rare cases, a given username or email
     //       can resolve to multiple customers:
@@ -46,7 +46,7 @@ export default class AnalyticsDataSource {
     // understand whether these duplicates are allowed, and if so, in which case,
     // then handle fetching a unique customer properly.
     // (Perhaps by a combination of username and email, for example).
-    return await coll.findOne({ username: username });
+    return await coll.findOne({ email: email });
   }
 
   // TODO idea: sort the transactions by date at the DB level,

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,7 +1,18 @@
+import { CustomerDbFormat } from "./types/Customer";
+
+export function mapCustomerDbToApiFormat(customer: CustomerDbFormat) {
+  return {
+    ...customer,
+    id: customer._id,
+    _id: undefined,
+  };
+}
+
 export const resolvers = {
   Query: {
     customer: async (_, { username }, { dataSources }) => {
-      return await dataSources.analytics.customer(username);
+      const data = await dataSources.analytics.customer(username);
+      return mapCustomerDbToApiFormat(data);
     },
     transactionBatch: async (_, { accountId }, { dataSources }) => {
       return await dataSources.analytics.transactionBatch(accountId);

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -10,8 +10,8 @@ export function mapCustomerDbToApiFormat(customer: CustomerDbFormat) {
 
 export const resolvers = {
   Query: {
-    customer: async (_, { username }, { dataSources }) => {
-      const data = await dataSources.analytics.customer(username);
+    customer: async (_, { email }, { dataSources }) => {
+      const data = await dataSources.analytics.customer(email);
       return mapCustomerDbToApiFormat(data);
     },
     transactionBatch: async (_, { accountId }, { dataSources }) => {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -27,6 +27,6 @@ type TransactionBatch {
 }
 
 type Query {
-  customer(username: String!): Customer
+  customer(email: String!): Customer
   transactionBatch(accountId: Int!): TransactionBatch
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,4 +1,5 @@
 type Customer {
+  id: String!
   username: String!
   name: String!
   email: String!

--- a/src/types/Customer.ts
+++ b/src/types/Customer.ts
@@ -1,6 +1,6 @@
 import { AccountId } from "./Account";
 
-export type Customer = {
+type CustomerBaseSchema = {
   username: string;
   name: string;
   address: string;
@@ -8,3 +8,7 @@ export type Customer = {
   email: string;
   accounts: AccountId[];
 };
+
+export type CustomerApiFormat = { id: string } & CustomerBaseSchema;
+
+export type CustomerDbFormat = { _id: string } & CustomerBaseSchema;

--- a/test/seed/seed.ts
+++ b/test/seed/seed.ts
@@ -1,8 +1,9 @@
-import { Customer } from "../../src/types/Customer";
+import { CustomerDbFormat } from "../../src/types/Customer";
 import { TransactionBatch } from "../../src/types/Transaction";
 
-export const seedCollCust: Customer[] = [
+export const seedCollCust: CustomerDbFormat[] = [
   {
+    _id: "14f93429-c9b9-4582-9b9f-c3557504fcb5",
     username: "appleseed",
     name: "Johnny Appleseed",
     address: "678 Orchard Lane, Apple Valley, CA 92307",
@@ -11,6 +12,7 @@ export const seedCollCust: Customer[] = [
     accounts: [987123, 345987],
   },
   {
+    _id: "8e24c42d-8611-444f-aea2-b7203180d145",
     username: "poppins",
     name: "Mary Poppins",
     address: "1600 Dream St, Los Angeles, CA 90028",

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -8,11 +8,12 @@ import AnalyticsDataSource from "../src/datasources/analytics";
 import { seedCollCust } from "./seed/seed";
 import { seedCollTxns } from "./seed/seed";
 import { ContextValue } from "../src/server";
-import { Customer } from "../src/types/Customer";
+import { CustomerApiFormat } from "../src/types/Customer";
 import { TransactionBatch } from "../src/types/Transaction";
 
 const typeDefs = fs.readFileSync("src/schema.graphql", "utf8");
-const KEY_HIDDEN_OBJECT_ID = "_id";
+const ID_KEY_API_FORMAT = "id";
+const ID_KEY_DB_FORMAT = "_id";
 
 let testDbServer: MongoMemoryServer;
 let testDbClient: MongoClient;
@@ -101,7 +102,7 @@ describe("server", () => {
           ?.transactionBatch as TransactionBatch;
         // Validate all fields except the hidden ID field.
         for (const key in actualBatch) {
-          if (key === KEY_HIDDEN_OBJECT_ID) continue;
+          if (key === ID_KEY_DB_FORMAT) continue;
           expect(actualBatch[key]).toEqual(expectedBatch[key]);
         }
       });
@@ -140,12 +141,16 @@ describe("server", () => {
 
         assert(response.body.kind === "single");
         expect(response.body.singleResult.errors).toBeUndefined();
-        const actualCustomer = response.body.singleResult.data
-          ?.customer as Customer;
-        // Validate all fields except the hidden ID field.
-        for (const key in actualCustomer) {
-          if (key === KEY_HIDDEN_OBJECT_ID) continue;
-          expect(actualCustomer[key]).toEqual(expectedCust[key]);
+        const actualCust = response.body.singleResult.data
+          ?.customer as CustomerApiFormat;
+        for (const key in actualCust) {
+          if (key === ID_KEY_API_FORMAT) {
+            expect(actualCust[ID_KEY_API_FORMAT]).toEqual(
+              expectedCust[ID_KEY_DB_FORMAT],
+            );
+          } else {
+            expect(actualCust[key]).toEqual(expectedCust[key]);
+          }
         }
       });
     });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -113,14 +113,14 @@ describe("server", () => {
     const indicesOfSeedCust = [...Array(seedCollCust.length).keys()];
     indicesOfSeedCust.forEach((index) => {
       const expectedCust = seedCollCust[index];
-      const expectedUsername = expectedCust.username;
+      const expectedEmail = expectedCust.email;
 
-      it(`returns the correct customer for the given username: ${expectedUsername}`, async () => {
+      it(`returns the correct customer for the given email: ${expectedEmail}`, async () => {
         const response = await testServer.executeOperation(
           {
             query: `#graphql
-              query GetCustomer($username: String!) {
-                customer(username: $username) {
+              query GetCustomer($email: String!) {
+                customer(email: $email) {
                   username
                   name
                   email
@@ -128,7 +128,7 @@ describe("server", () => {
                 }
               }
             `,
-            variables: { username: expectedUsername },
+            variables: { email: expectedEmail },
           },
           {
             contextValue: {


### PR DESCRIPTION
### Summary
Fetch customer data by `email` not `username`, so that the info about the customer that logged in, can be reused in `/dashboard`.

### Main changes
- Change `customer` query to use `email` as the parameter, not `username`
  - While enabling login experience by `username` (https://github.com/chohanbin/flywheel-web-service/pull/9), it was discovered that `jwt` token employed by NextAuth lib supports `id`, `email`, and `name` fields but not `username`. 
- Allow `customer` object to expose `id`.
  - It may be useful in the future (such as using as the `path` variable for customer `/edit` page.)
- Update to `README`: Ensure running data-service container with `--name data-service`, so that it can be referenced by web-service running in a container.

### Validations

Before
<img width="1389" alt="Screenshot 2024-06-09 at 7 10 49 PM" src="https://github.com/chohanbin/flywheel-data-service/assets/5660356/cd957114-3a32-4f8c-a1e2-3799aa772ae3">

After
<img width="1404" alt="Screenshot 2024-06-09 at 7 12 05 PM" src="https://github.com/chohanbin/flywheel-data-service/assets/5660356/fbac29e0-427c-4144-a63f-91670e18c4b8">

